### PR TITLE
[ISSUE] 휴장일에는 주가 데이터 안불러오도록 설정

### DIFF
--- a/.github/workflows/stock-batch.yml
+++ b/.github/workflows/stock-batch.yml
@@ -24,7 +24,7 @@ jobs:
                 uses: actions/setup-java@v2
                 with:
                     java-version: '11'
-                    distribution: 'temurin'
+                    distribution: 'zulu'
             -   name: Build with Gradle
                 uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7
                 with:
@@ -72,4 +72,4 @@ jobs:
                     -H 'Accept: application/vnd.github+json' \
                     -H "Authorization: Bearer ${{secrets.PERSONAL_ACCESS_KEY}}" \
                     -d '{"event_type": "stock-batch", "client_payload": { "repository":"stock", "project": "stock-batch", "runNumber":"${{github.run_number}}" }}'
-            
+

--- a/.github/workflows/stock-domain.yml
+++ b/.github/workflows/stock-domain.yml
@@ -22,7 +22,7 @@ jobs:
                 uses: actions/setup-java@v2
                 with:
                     java-version: '11'
-                    distribution: 'temurin'
+                    distribution: 'zulu'
             -   name: Build with Gradle
                 uses: gradle/gradle-build-action@937999e9cc2425eddc7fd62d1053baf041147db7
                 with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ subprojects {
             exclude(group = "org.junit.vintage", module = "junit-vintage-engine")
         }
         testImplementation("io.github.javaunit:autoparams-lombok:0.0.3")
+        testImplementation("org.mockito:mockito-inline:3.7.7")
     }
 
     configurations {

--- a/stock-batch/src/main/java/com/jh/stock/batch/job/quote/processor/QuoteProcessor.java
+++ b/stock-batch/src/main/java/com/jh/stock/batch/job/quote/processor/QuoteProcessor.java
@@ -2,6 +2,7 @@ package com.jh.stock.batch.job.quote.processor;
 
 import com.jh.stock.domain.MyQuote;
 import com.jh.stock.domain.MyStock;
+import com.jh.stock.domain.StockMarketHolidays;
 import com.jh.stock.domain.dto.MyQuoteDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,9 @@ import java.sql.Timestamp;
 public class QuoteProcessor implements ItemProcessor<MyStock, MyQuote> {
     @Override
     public MyQuote process(MyStock item) throws Exception {
+        if (StockMarketHolidays.isHolidayToday()) {
+            return null;
+        }
         return getQuoteFromYahooFinancial(item.getTicker());
     }
 

--- a/stock-batch/src/main/java/com/jh/stock/batch/job/quote/writer/QuoteWriter.java
+++ b/stock-batch/src/main/java/com/jh/stock/batch/job/quote/writer/QuoteWriter.java
@@ -9,6 +9,7 @@ import org.springframework.batch.item.ItemWriter;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Objects;
 
 @Slf4j
 @StepScope
@@ -19,11 +20,9 @@ public class QuoteWriter implements ItemWriter<MyQuote> {
 
     @Override
     public void write(List<? extends MyQuote> quoteList) throws Exception {
-        quoteList.forEach(quote -> {
-            if (quote != null) {
-                myQuoteService.save(quote);
-                log.info("티커 : {}, 시장가 : {}, 등락폭 : {}, 거래량 : {}", quote.getTicker(), quote.getMarketPrice(), quote.getFluctuation(), quote.getTransactionVolume());
-            }
+        quoteList.stream().filter(Objects::nonNull).forEach(quote -> {
+            myQuoteService.save(quote);
+            log.info("티커 : {}, 시장가 : {}, 등락폭 : {}, 거래량 : {}", quote.getTicker(), quote.getMarketPrice(), quote.getFluctuation(), quote.getTransactionVolume());
         });
     }
 }

--- a/stock-domain/src/main/java/com/jh/stock/domain/StockMarketHolidays.java
+++ b/stock-domain/src/main/java/com/jh/stock/domain/StockMarketHolidays.java
@@ -1,0 +1,36 @@
+package com.jh.stock.domain;
+
+import org.springframework.cglib.core.Local;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class StockMarketHolidays {
+    private static Set<String> HOLIDAY_KR;
+    static {
+        String[] stockMarketHolidays = {
+            "2023-01-23", "2023-01-24", "2023-03-01", "2023-05-01", "2023-05-05", "2023-06-06", "2023-08-15",
+            "2023-09-28", "2023-09-29", "2023-10-03", "2023-10-09", "2023-12-25", "2023-12-29", "2024-01-01",
+            "2024-02-09", "2024-02-12", "2024-03-01", "2024-05-01", "2024-05-06", "2024-05-15", "2024-06-06",
+            "2024-08-15", "2024-09-16", "2024-09-17", "2024-09-18", "2024-10-03", "2024-10-09", "2024-12-25",
+            "2024-12-31", "2025-01-01", "2025-01-28", "2025-01-29", "2025-01-30", "2025-03-03", "2025-05-01",
+            "2025-05-05", "2025-05-06", "2025-06-06", "2025-08-15", "2025-10-03", "2025-10-06", "2025-10-07",
+            "2025-10-08", "2025-10-09", "2025-12-25", "2025-12-31", "2026-01-01", "2026-02-16", "2026-02-17",
+            "2026-02-18", "2026-03-02", "2026-05-01", "2026-05-05", "2026-08-17", "2026-09-24", "2026-09-25",
+            "2026-10-05", "2026-10-09", "2026-12-25", "2026-12-31", "2027-01-01", "2027-02-08", "2027-02-09",
+            "2027-03-01", "2027-05-05"};
+
+        HOLIDAY_KR = new HashSet<>(Arrays.asList(stockMarketHolidays));
+    }
+    public static boolean isHolidayToday() {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        String todayStr = today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+        return HOLIDAY_KR.contains(todayStr);
+    }
+}

--- a/stock-domain/src/main/java/com/jh/stock/domain/StockMarketHolidays.java
+++ b/stock-domain/src/main/java/com/jh/stock/domain/StockMarketHolidays.java
@@ -1,7 +1,6 @@
 package com.jh.stock.domain;
 
-import org.springframework.cglib.core.Local;
-
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -9,8 +8,12 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import static java.time.DayOfWeek.SATURDAY;
+import static java.time.DayOfWeek.SUNDAY;
+
 public class StockMarketHolidays {
-    private static Set<String> HOLIDAY_KR;
+    private static final Set<String> HOLIDAY_KR;
+
     static {
         String[] stockMarketHolidays = {
             "2023-01-23", "2023-01-24", "2023-03-01", "2023-05-01", "2023-05-05", "2023-06-06", "2023-08-15",
@@ -26,8 +29,14 @@ public class StockMarketHolidays {
 
         HOLIDAY_KR = new HashSet<>(Arrays.asList(stockMarketHolidays));
     }
+
     public static boolean isHolidayToday() {
         LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        DayOfWeek dayOfWeek = today.getDayOfWeek();
+        if (dayOfWeek == SUNDAY || dayOfWeek == SATURDAY) {
+            return true;
+        }
 
         String todayStr = today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 

--- a/stock-domain/src/test/java/com/jh/stock/domain/StockMarketHolidaysTest.java
+++ b/stock-domain/src/test/java/com/jh/stock/domain/StockMarketHolidaysTest.java
@@ -15,7 +15,7 @@ class StockMarketHolidaysTest {
 
     @Test
     void isHolidayToday_return_false_test() {
-        LocalDate expected = LocalDate.of(2023, 4, 1);
+        LocalDate expected = LocalDate.of(2023, 4, 3);
         try (MockedStatic<LocalDate> mocked = mockStatic(LocalDate.class)) {
             when(LocalDate.now(any(ZoneId.class))).thenReturn(expected);
             assertThat(StockMarketHolidays.isHolidayToday()).isFalse();

--- a/stock-domain/src/test/java/com/jh/stock/domain/StockMarketHolidaysTest.java
+++ b/stock-domain/src/test/java/com/jh/stock/domain/StockMarketHolidaysTest.java
@@ -16,7 +16,12 @@ class StockMarketHolidaysTest {
     @Test
     void isHolidayToday_return_false_test() {
         LocalDate expected = LocalDate.of(2023, 4, 3);
-        try (MockedStatic<LocalDate> mocked = mockStatic(LocalDate.class)) {
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+
+        try (MockedStatic<LocalDate> mocked = mockStatic(LocalDate.class);
+             MockedStatic<ZoneId> mockedZoneId = mockStatic(ZoneId.class)
+        ) {
+            when(ZoneId.of("Asia/Seoul")).thenReturn(zoneId);
             when(LocalDate.now(any(ZoneId.class))).thenReturn(expected);
             assertThat(StockMarketHolidays.isHolidayToday()).isFalse();
         }
@@ -25,7 +30,12 @@ class StockMarketHolidaysTest {
     @Test
     void isHolidayToday_return_true_test() {
         LocalDate expected = LocalDate.of(2023, 12, 25);
-        try (MockedStatic<LocalDate> mocked = mockStatic(LocalDate.class)) {
+        ZoneId zoneId = ZoneId.of("Asia/Seoul");
+
+        try (MockedStatic<LocalDate> mocked = mockStatic(LocalDate.class);
+             MockedStatic<ZoneId> mockedZoneId = mockStatic(ZoneId.class)
+        ) {
+            when(ZoneId.of("Asia/Seoul")).thenReturn(zoneId);
             when(LocalDate.now(any(ZoneId.class))).thenReturn(expected);
             assertThat(StockMarketHolidays.isHolidayToday()).isTrue();
         }

--- a/stock-domain/src/test/java/com/jh/stock/domain/StockMarketHolidaysTest.java
+++ b/stock-domain/src/test/java/com/jh/stock/domain/StockMarketHolidaysTest.java
@@ -6,7 +6,7 @@ import org.mockito.MockedStatic;
 import java.time.LocalDate;
 import java.time.ZoneId;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;

--- a/stock-domain/src/test/java/com/jh/stock/domain/StockMarketHolidaysTest.java
+++ b/stock-domain/src/test/java/com/jh/stock/domain/StockMarketHolidaysTest.java
@@ -1,0 +1,33 @@
+package com.jh.stock.domain;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class StockMarketHolidaysTest {
+
+    @Test
+    void isHolidayToday_return_false_test() {
+        LocalDate expected = LocalDate.of(2023, 4, 1);
+        try (MockedStatic<LocalDate> mocked = mockStatic(LocalDate.class)) {
+            when(LocalDate.now(any(ZoneId.class))).thenReturn(expected);
+            assertThat(StockMarketHolidays.isHolidayToday()).isFalse();
+        }
+    }
+
+    @Test
+    void isHolidayToday_return_true_test() {
+        LocalDate expected = LocalDate.of(2023, 12, 25);
+        try (MockedStatic<LocalDate> mocked = mockStatic(LocalDate.class)) {
+            when(LocalDate.now(any(ZoneId.class))).thenReturn(expected);
+            assertThat(StockMarketHolidays.isHolidayToday()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
* 휴장일에는 주가 데이터 안불러오도록 설정

## Description
* https://open.krx.co.kr/contents/MKD/01/0110/01100305/MKD01100305.jsp 에서 데이터 받은 다음 하드코딩해놓음.

## 기타
* 관련 이슈: #17 
